### PR TITLE
Stabilize polling lifecycle + standby when broadcast finished

### DIFF
--- a/.github/workflows/companion-module-checks.yaml
+++ b/.github/workflows/companion-module-checks.yaml
@@ -15,4 +15,3 @@ jobs:
     uses: bitfocus/actions/.github/workflows/module-checks.yaml@main
     # with:
     #   upload-artifact: true # uncomment this to upload the built package as an artifact to this workflow that you can download and share with others
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+`ballscore-broadcast` is a **Bitfocus Companion module** — a plugin loaded into [Companion](https://bitfocus.io/companion) so an operator can drive Ball Score's on-air graphics from a Stream Deck (or Companion's web buttons). It is the remote control surface for the broadcast; it does not render graphics itself. It talks to `page-ui`'s REST API over HTTP — see the workspace-root `../CLAUDE.md` for how the three projects fit together.
+
+This repo is published to Bitfocus's module registry (`github.com/bitfocus/companion-module-ballscore-broadcast`); it follows their module conventions and is not free to restructure like an in-house app.
+
+## Commands
+
+Package manager is **Yarn 4** (`packageManager: yarn@4.9.1`, `.yarnrc.yml`); Node `^22.14`. The module is **ESM** (`"type": "module"`) — TS imports must use `.js` extensions (e.g. `import { GetConfigFields } from './config.js'`) even though the source is `.ts`.
+
+- `yarn build` — `rimraf dist && tsc -p tsconfig.build.json`. Output goes to `dist/` (the manifest entrypoint is `../dist/main.js`). Companion loads `dist/`, so build before testing in Companion.
+- `yarn dev` — `tsc --watch`; the dev loop.
+- `yarn lint` / `yarn lint:raw --fix` — eslint (flat config, `eslint.config.mjs`).
+- `yarn format` — prettier (config inherited from `@companion-module/tools`).
+- `yarn package` — `build` then `companion-module-build`, producing the `*.tgz` distributable.
+
+`husky` + `lint-staged` run prettier/eslint on commit (`postinstall` installs the hooks).
+
+Note: `pkg/` and the `*.tgz` files are built/packaged artifacts, not source — don't hand-edit them. `companion/manifest.json` `version` is `0.0.0` in source and stamped at package time; the real version lives in `package.json`.
+
+## Architecture
+
+The Companion SDK (`@companion-module/base`) drives everything. `runEntrypoint(BallScoreBroadcastModuleInstance, UpgradeScripts)` in `src/main.ts` is the entry point. The instance class wires together five concern-specific modules, each a single exported `Update*` function that registers definitions with the SDK:
+
+- `config.ts` — web-config fields: `secretKey` (text), `environment` (dropdown: prod/test/dev/local), and `timeout` (number, ms; default 4000).
+- `api-service.ts` — `ApiService`, the only HTTP layer (axios). Maps `environment` → base URL and holds the request config.
+- `actions.ts` — button actions (`toggle_component`, `select_from_lineup`, `select_pitcher`).
+- `feedbacks.ts` — boolean button-style feedbacks (`componentState`, `batterState`, `playerSelectionState`, `playerOnAirState`).
+- `variables.ts` — Companion variables for lineup/pitcher numbers, names, and pre-formatted button labels.
+- `presets.ts` — ready-made button presets combining the above.
+- `upgrades.ts` — `UpgradeScripts` for migrating saved configs across versions (currently empty).
+
+**Config & connection lifecycle.** `init()` registers all definitions (actions/feedbacks/variables/presets) unconditionally, then bails to `InstanceStatus.BadConfig` if `secretKey` is empty; otherwise `connectToBallScore()` constructs the `ApiService` and starts the poll loop. The loop is started **without** awaiting a first fetch, so a startup blip (API briefly down) self-heals instead of leaving the connection dead. `configUpdated()` reconnects only when `environment`, `secretKey`, or `timeout` changed.
+
+**Polling model (self-healing).** There is no push from the server. `pollOnce()` is a single in-flight request that schedules the _next_ tick in a `finally` (recursive `setTimeout`, never `setInterval`), so requests can't overlap. Cadence is derived from the payload: `ACTIVE_POLL_MS` (5s) normally, dropping to `STANDBY_POLL_MS` (60s) when `data.finished === true`, and auto-resuming to fast polling when an active game reappears. On success it sets `InstanceStatus.Ok` (with a "Broadcast finished — standby" message when finished) and resets the failure counter; a single failed poll is tolerated and only flips to `Disconnected` after `MAX_CONSECUTIVE_FAILURES` (2), keeping the previous `self.data` so feedbacks still show last-known state. 401/403 surfaces `AuthenticationFailure` immediately but keeps retrying (auth is user-fixable). The `broadcastTimer` handle is cleared on `destroy()` and on reconnect via `stopPolling()`. The axios `timeout` defaults to 4000ms (configurable, kept below the active poll period).
+
+**`self.data` is the single source of truth.** `BroadcastCompanionData` (lineups, pitchers, current `lowerThird`, and `controls[]`) is fetched once per tick and every feedback/variable reads from it synchronously. Actions optimistically mutate `self.data` locally after a successful API call (e.g. `toggle_component` flips the local `action`) and immediately `checkFeedbacks` so buttons respond without waiting for the next poll.
+
+## API contract with `page-ui`
+
+`ApiService` calls these endpoints under `<env-base>/api/v1` (`www`/`test`/`dev`.ballscore.app, or `http://localhost:4200` for `local`):
+
+- `GET /companion` — the aggregate poll payload (`BroadcastCompanionData`, incl. `finished?: boolean`). Empty `controls` is treated as valid (not-yet-configured broadcast); only a missing/malformed payload throws.
+- `PUT /controls/:component/toggle` — toggle one on-air component.
+- `PUT /lower-third/:playerGuid` — select a player for the lower-third graphic.
+- `GET /broadcasts/:secretKey/controls`, `GET /controls/:component` — read helpers.
+
+**Auth is the `x-secret-key` header**, set to the configured `secretKey`. Subtle: the same `secretKey` is also used as the broadcast id in the `/broadcasts/:secretKey/controls` path — it is both credential and resource key. The server side of this contract lives in `../ball-score-2-b-page/server/api/` (`companion.js`, `broadcasts-controls.js`, `lower-third.js`); see `../ball-score-2-b-page/CLAUDE.md` → "Express server".
+
+**Keep the component list in sync.** The component ids in `actions.ts` and `feedbacks.ts` dropdowns (`status`, `batter`, `pitcher`, `lowerThird`, `boxScore`, `intro`, `awayLineup`, `homeLineup`, `awayDefence`, `homeDefence`, `customTable`) must match the `ControlComponent` union in `page-ui` (`../ball-score-2-b-page/src/app/model/broadcast/control.ts`). Both dropdowns use `allowCustom: true`, so a new component can be controlled by typing its id without releasing a new module version — but the curated list should still be kept aligned.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ballscore-broadcast",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -31,7 +31,7 @@ export function UpdateActions(self: BallScoreBroadcastModuleInstance): void {
 				try {
 					const component: string = event.options.component ? event.options.component.toString() : 'status'
 					await self.apiService.toggleComponent(component)
-					const localComponent = self.data.controls.find((c) => c.component === component)
+					const localComponent = self.data?.controls?.find((c) => c.component === component)
 					if (localComponent) {
 						localComponent.action = localComponent.action === 'on' ? 'off' : 'on'
 					}
@@ -72,9 +72,9 @@ export function UpdateActions(self: BallScoreBroadcastModuleInstance): void {
 					const num: number = event.options.num ? Number(event.options.num) : 1
 					let guid: string | undefined
 					if (team === 'away') {
-						guid = self.data.awayLineup[num - 1].guid
+						guid = self.data?.awayLineup?.[num - 1]?.guid
 					} else {
-						guid = self.data.homeLineup[num - 1].guid
+						guid = self.data?.homeLineup?.[num - 1]?.guid
 					}
 					await self.apiService.selectLowerThird(guid)
 					self.data = await self.apiService.getCompanionData()
@@ -104,9 +104,9 @@ export function UpdateActions(self: BallScoreBroadcastModuleInstance): void {
 					const team: string = event.options.team ? event.options.team.toString() : 'away'
 					let guid: string | undefined
 					if (team === 'away') {
-						guid = self.data.awayPitcher?.guid
+						guid = self.data?.awayPitcher?.guid
 					} else {
-						guid = self.data.homePitcher?.guid
+						guid = self.data?.homePitcher?.guid
 					}
 					if (guid) {
 						await self.apiService.selectLowerThird(guid)

--- a/src/api-service.ts
+++ b/src/api-service.ts
@@ -1,10 +1,12 @@
 import { BallScoreBroadcastModuleConfig } from './config.js'
 import axios from 'axios'
-import * as console from 'node:console'
+
+export const DEFAULT_TIMEOUT_MS = 4000
 
 export class ApiService {
 	private readonly secretKey: string
 	private readonly baseUrl: string | undefined
+	private readonly timeout: number
 
 	private get requestConfig() {
 		return {
@@ -13,13 +15,13 @@ export class ApiService {
 				Accept: 'application/json',
 				'x-secret-key': this.secretKey,
 			},
-			timeout: 1000,
+			timeout: this.timeout,
 		}
 	}
 
 	constructor(config: BallScoreBroadcastModuleConfig) {
-		console.log('initalizing ApiService with config', config)
 		this.secretKey = config.secretKey
+		this.timeout = config.timeout && config.timeout > 0 ? config.timeout : DEFAULT_TIMEOUT_MS
 		switch (config.environment) {
 			case 'prod':
 				this.baseUrl = 'https://www.ballscore.app/api/v1'
@@ -62,10 +64,11 @@ export class ApiService {
 
 	async getCompanionData(): Promise<BroadcastCompanionData> {
 		const url = `${this.baseUrl}/companion`
-		console.log('gettingCompanionData', url, this.requestConfig)
 		const response = await axios.get<BroadcastCompanionData>(url, this.requestConfig)
-		if (!response?.data?.controls?.length) {
-			throw new Error('Error getting companion data from API!')
+		// An empty controls array is valid (broadcast not configured yet); only a
+		// missing/malformed payload is an error.
+		if (!response?.data || !Array.isArray(response.data.controls)) {
+			throw new Error('Malformed companion data from API!')
 		}
 		return response.data
 	}
@@ -73,6 +76,7 @@ export class ApiService {
 
 export interface BroadcastCompanionData {
 	gameId?: string
+	finished?: boolean
 	awayLineup: Player[]
 	homeLineup: Player[]
 	awayPitcher?: Player

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { type SomeCompanionConfigField } from '@companion-module/base'
 export interface BallScoreBroadcastModuleConfig {
 	secretKey: string
 	environment: string
+	timeout?: number
 }
 
 export function GetConfigFields(): SomeCompanionConfigField[] {
@@ -27,6 +28,15 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 				{ id: 'local', label: 'Local' },
 			],
 			default: 'prod',
+		},
+		{
+			id: 'timeout',
+			type: 'number',
+			label: 'API timeout (ms)',
+			width: 8,
+			min: 500,
+			max: 30000,
+			default: 4000,
 		},
 	]
 }

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -43,7 +43,8 @@ export function UpdateFeedbacks(self: BallScoreBroadcastModuleInstance): void {
 			callback: async (feedback) => {
 				try {
 					return (
-						self.data.controls.find((control: any) => control.component === feedback.options.component)?.action === 'on'
+						self.data?.controls?.find((control: any) => control.component === feedback.options.component)?.action ===
+						'on'
 					)
 				} catch (_error) {
 					return false
@@ -80,9 +81,9 @@ export function UpdateFeedbacks(self: BallScoreBroadcastModuleInstance): void {
 				try {
 					const index: number = feedback.options.lineupSpot ? Number(feedback.options.lineupSpot) - 1 : 0
 					if (feedback.options.team === 'away') {
-						return self.data.awayLineup[index].isUp
+						return self.data?.awayLineup?.[index]?.isUp ?? false
 					} else {
-						return self.data.homeLineup[index].isUp
+						return self.data?.homeLineup?.[index]?.isUp ?? false
 					}
 				} catch (error: any) {
 					self.log('error', `Error getting batter state: ${error.message}`)
@@ -150,7 +151,7 @@ export function UpdateFeedbacks(self: BallScoreBroadcastModuleInstance): void {
 				try {
 					return (
 						isPlayerSelected(feedback.options) &&
-						self.data.controls.find((control: any) => control.component === 'lowerThird')?.action === 'on'
+						self.data?.controls?.find((control: any) => control.component === 'lowerThird')?.action === 'on'
 					)
 				} catch (error: any) {
 					self.log('error', `Error getting player on air state: ${error?.message}`)
@@ -164,16 +165,16 @@ export function UpdateFeedbacks(self: BallScoreBroadcastModuleInstance): void {
 		try {
 			if (feedBackOptions.lineupSpot === 10) {
 				if (feedBackOptions.team === 'away') {
-					return !!self.data.awayPitcher?.guid && self.data.awayPitcher?.guid === self.data.lowerThird?.guid
+					return !!self.data?.awayPitcher?.guid && self.data?.awayPitcher?.guid === self.data?.lowerThird?.guid
 				} else {
-					return !!self.data.homePitcher?.guid && self.data.homePitcher?.guid === self.data.lowerThird?.guid
+					return !!self.data?.homePitcher?.guid && self.data?.homePitcher?.guid === self.data?.lowerThird?.guid
 				}
 			}
 			const index: number = feedBackOptions.lineupSpot ? Number(feedBackOptions.lineupSpot) - 1 : 0
 			if (feedBackOptions.team === 'away') {
-				return self.data.awayLineup[index].guid === self.data.lowerThird?.guid
+				return self.data?.awayLineup?.[index]?.guid === self.data?.lowerThird?.guid
 			} else {
-				return self.data.homeLineup[index].guid === self.data.lowerThird?.guid
+				return self.data?.homeLineup?.[index]?.guid === self.data?.lowerThird?.guid
 			}
 		} catch (error: any) {
 			self.log('error', `Error getting player state: ${error?.message}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,117 +7,141 @@ import { UpdateFeedbacks } from './feedbacks.js'
 import { UpdatePresetDefinitions } from './presets.js'
 import { ApiService, BroadcastCompanionData } from './api-service.js'
 
+// Poll cadence: fast while a game is live, slow standby once it has finished
+// (auto-resumes to the fast rate as soon as an active game reappears).
+const ACTIVE_POLL_MS = 5000
+const STANDBY_POLL_MS = 60000
+// Tolerate the odd dropped request before flagging the connection as down.
+const MAX_CONSECUTIVE_FAILURES = 2
+
 export class BallScoreBroadcastModuleInstance extends InstanceBase<BallScoreBroadcastModuleConfig> {
 	config!: BallScoreBroadcastModuleConfig // Setup in init()
 	apiService!: ApiService
 	data!: BroadcastCompanionData
-	broadcastTimer!: NodeJS.Timeout | null
+	private broadcastTimer: NodeJS.Timeout | null = null
+	private stopped = true
+	private consecutiveFailures = 0
+	private lastControlsKey = ''
 
 	constructor(internal: unknown) {
 		super(internal)
 	}
 
-	private subscribeToBroadcast(): NodeJS.Timeout {
-		// Clear any existing timer
-		if (this.broadcastTimer) {
-			clearInterval(this.broadcastTimer)
-		}
-
-		// Set up a new timer that calls getCompanionData every 5 seconds
-		this.broadcastTimer = setInterval(() => {
-			this.apiService
-				.getCompanionData()
-				.then((data: BroadcastCompanionData) => {
-					this.data = data
-					this.checkFeedbacks('batterState', 'playerSelectionState', 'playerOnAirState', 'componentState')
-					updateLineupAndPitchersVariables(this)
-				})
-				.catch((error: any) => {
-					this.log('error', `Error getting companion data: ${error?.message}`)
-					this.updateStatus(InstanceStatus.Disconnected, error.message)
-				})
-		}, 5000)
-
-		// Return the timer so it can be canceled if needed
-		return this.broadcastTimer
+	private startPolling(): void {
+		this.stopPolling()
+		this.stopped = false
+		this.consecutiveFailures = 0
+		this.lastControlsKey = ''
+		// Kick off immediately; each tick schedules the next one itself.
+		void this.pollOnce()
 	}
 
-	private async connectToBallScore(config: BallScoreBroadcastModuleConfig): Promise<void> {
+	private stopPolling(): void {
+		this.stopped = true
+		if (this.broadcastTimer) {
+			clearTimeout(this.broadcastTimer)
+			this.broadcastTimer = null
+		}
+	}
+
+	private scheduleNextPoll(delayMs: number): void {
+		if (this.stopped) return
+		if (this.broadcastTimer) clearTimeout(this.broadcastTimer)
+		this.broadcastTimer = setTimeout(() => {
+			void this.pollOnce()
+		}, delayMs)
+	}
+
+	// A single poll. A recursive setTimeout (scheduled in `finally`) guarantees
+	// requests never overlap, and keeps the connection self-healing.
+	private async pollOnce(): Promise<void> {
+		let nextDelay = ACTIVE_POLL_MS
+		try {
+			const data = await this.apiService.getCompanionData()
+			this.data = data
+			this.consecutiveFailures = 0
+
+			const finished = data.finished === true
+			nextDelay = finished ? STANDBY_POLL_MS : ACTIVE_POLL_MS
+			this.updateStatus(InstanceStatus.Ok, finished ? 'Broadcast finished — standby' : undefined)
+
+			// Rebuild presets only when the set of controls changes (cheap dedup).
+			const controlsKey = data.controls
+				.map((c) => c.component)
+				.sort()
+				.join(',')
+			if (controlsKey !== this.lastControlsKey) {
+				this.lastControlsKey = controlsKey
+				UpdatePresetDefinitions(this)
+			}
+
+			this.checkFeedbacks('batterState', 'playerSelectionState', 'playerOnAirState', 'componentState')
+			updateLineupAndPitchersVariables(this)
+		} catch (error: any) {
+			this.consecutiveFailures++
+			this.log('error', `Error getting companion data: ${error?.message}`)
+			// Auth problems are user-fixable via config: surface immediately but keep
+			// retrying so it recovers once the key/permissions are corrected.
+			if (error.response?.status === 401 || error.response?.status === 403) {
+				this.updateStatus(InstanceStatus.AuthenticationFailure, error?.message)
+			} else if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+				this.updateStatus(InstanceStatus.Disconnected, error?.message)
+			}
+			// Keep the previous `this.data` so feedbacks keep showing last-known state.
+			nextDelay = ACTIVE_POLL_MS
+		} finally {
+			this.scheduleNextPoll(nextDelay)
+		}
+	}
+
+	private connectToBallScore(config: BallScoreBroadcastModuleConfig): void {
 		this.log('debug', 'connectingToBallScore')
 		this.updateStatus(InstanceStatus.Connecting)
-		try {
-			this.apiService = new ApiService(config)
-			this.data = await this.apiService.getCompanionData()
-			this.log('debug', 'got response or timeout from Ball Score')
-			this.updateStatus(InstanceStatus.Ok)
-			this.subscribeToBroadcast()
-		} catch (error: any) {
-			if (error.response?.status === 401 || error.response?.status === 403) {
-				this.log('warn', `Error connecting to  Ball Score: ${error?.message}`)
-				this.updateStatus(InstanceStatus.AuthenticationFailure, error.message)
-				return
-			}
-			if (error.response?.status === 404) {
-				this.log('warn', `Error connecting to broadcast: ${error?.message}`)
-				this.updateStatus(InstanceStatus.ConnectionFailure, error.message)
-				return
-			}
-			this.log('error', `Error connecting to Ball Score: ${error?.message}`)
-			this.updateStatus(InstanceStatus.UnknownError, error.message)
-			throw error
-		}
+		this.apiService = new ApiService(config)
+		// Always start the loop, even before the first successful fetch, so a
+		// startup blip (API briefly down) self-heals without a manual reconnect.
+		this.startPolling()
 	}
 
 	async init(config: BallScoreBroadcastModuleConfig): Promise<void> {
 		this.config = config
 
+		// Definitions don't depend on live data — expose them regardless of state.
+		this.updateActions()
+		this.updateFeedbacks()
+		this.updateVariableDefinitions()
+		UpdatePresetDefinitions(this)
+
 		if (!config.secretKey || config.secretKey === '') {
-			return this.updateStatus(InstanceStatus.BadConfig, 'Make sure to set the Secret Key config property.')
+			this.updateStatus(InstanceStatus.BadConfig, 'Make sure to set the Secret Key config property.')
+			return
 		}
 
-		try {
-			await this.connectToBallScore(config)
-
-			this.updateActions() // export actions
-			this.updateFeedbacks() // export feedbacks
-			this.updateVariableDefinitions() // export variable definitions
-			UpdatePresetDefinitions(this) // export preset definitions
-		} catch (error: any) {
-			this.log('error', `Error connecting to Ball Score: ${error?.message}`)
-			this.updateStatus(InstanceStatus.ConnectionFailure, error.message)
-		}
+		this.connectToBallScore(config)
 	}
 
 	// When module gets deleted
 	async destroy(): Promise<void> {
 		this.log('debug', 'destroy')
-		// Clean up the timer when the module is destroyed
-		if (this.broadcastTimer) {
-			clearInterval(this.broadcastTimer)
-			this.broadcastTimer = null
-		}
+		this.stopPolling()
 	}
 
 	async configUpdated(config: BallScoreBroadcastModuleConfig): Promise<void> {
 		if (!config.secretKey || config.secretKey === '') {
+			this.stopPolling()
+			this.config = config
 			return this.updateStatus(InstanceStatus.BadConfig, 'Make sure to set the Secret Key config property.')
 		}
 
 		const isReconnectionNeeded: boolean =
-			config.environment != this.config.environment || config.secretKey != this.config.secretKey
-		//if environment or secretKey has changed, reconnect to broadcast
-		if (isReconnectionNeeded) {
-			// Clear any existing timer when config is updated
-			if (this.broadcastTimer) {
-				clearInterval(this.broadcastTimer)
-				this.broadcastTimer = null
-			}
-			await this.connectToBallScore(config)
-
-			// Refresh presets when config is updated
-			UpdatePresetDefinitions(this)
-		}
+			config.environment != this.config.environment ||
+			config.secretKey != this.config.secretKey ||
+			config.timeout != this.config.timeout
 		this.config = config
+		// Reconnect when the connection parameters change (new ApiService + restart loop).
+		if (isReconnectionNeeded) {
+			this.connectToBallScore(config)
+		}
 	}
 
 	// Return config fields for web config


### PR DESCRIPTION
## What & why

The module was fragile against transient conditions (slow network, the API briefly down, an empty/uninitialized broadcast) and kept the page-ui backend polled at a fixed 5s even after a game ended. This reworks the polling lifecycle to be self-healing and adds a standby mode.

## Changes

**Self-scheduling poll loop (`src/main.ts`)** — replaces the fixed `setInterval` with a single in-flight `pollOnce()` that schedules the next tick in `finally` (recursive `setTimeout`), so requests can never overlap.
- **Recovers to OK:** success now sets `InstanceStatus.Ok` — fixes the prior bug where one failed poll left the connection stuck on `Disconnected` forever (the old success branch never reset the status).
- **Tolerates blips:** only flips to `Disconnected` after `MAX_CONSECUTIVE_FAILURES` (2); keeps the last `data` so feedbacks still show last-known state.
- **Self-healing startup:** the loop starts even before the first successful fetch, so a startup blip no longer leaves the module dead until a manual reconnect. `401/403` surfaces `AuthenticationFailure` but keeps retrying (auth is user-fixable).

**Standby when finished** — when `/companion` reports `finished: true`, the poll drops from 5s (`ACTIVE_POLL_MS`) to 60s (`STANDBY_POLL_MS`) and shows a "Broadcast finished — standby" status; it auto-resumes fast polling when an active game reappears. No manual reconnect needed.

**`api-service.ts`** — request timeout raised 1000ms → 4000ms (configurable, kept below the active poll period); empty `controls` is now treated as a valid not-yet-configured broadcast instead of a hard error; added `finished?: boolean` to `BroadcastCompanionData`; removed two `console.log`s that were printing the config (incl. the secret key).

**`config.ts`** — new optional `timeout` (ms) field.

**`actions.ts` / `feedbacks.ts`** — optional-chaining guards so short/partial lineups don't throw.

Version bumped to `1.0.2`; `CLAUDE.md` added.

## Dependency

The standby behavior relies on the `/companion` endpoint returning `finished` (added in `ball-score-2-b-page` — merged to its `test` branch, needs prod deploy for prod users). If the field is absent the module degrades gracefully to always-active polling.

## Test plan
- [x] `yarn build`, `yarn lint` clean
- [x] Dev-mode reload in Companion 4: pressing buttons works (no "unsupported function")
- [x] Stop page-ui mid-session → connection does not immediately drop and recovers to OK
- [x] Finish a game → status shows standby and polling drops to ~60s; start a new game → resumes within ~60s